### PR TITLE
Fix syntactic error on nightly Rust

### DIFF
--- a/src/container/args.rs
+++ b/src/container/args.rs
@@ -64,7 +64,7 @@ impl <'r> Deref for Arg<'r> {
 
 
 impl <'r> AsRef<for <'t> Type<'t> + 'r> for Arg<'r> {
-    fn as_ref(&self) -> & for <'t> Type<'t> + 'r {
+    fn as_ref(&self) -> &(for <'t> Type<'t> + 'r) {
         &**self
     }
 }


### PR DESCRIPTION
`& for <'t> Type<'t> + 'r` is are actually a syntactic error because `+` has lower priority than `&`, but this specific case was accepted by mistake (https://github.com/rust-lang/rust/issues/39317). This will be fixed soon (https://github.com/rust-lang/rust/pull/40043) and this code is going to stop compiling.